### PR TITLE
Refactor MoveMessageTo and update services in Program.cs

### DIFF
--- a/Blink3.API/Program.cs
+++ b/Blink3.API/Program.cs
@@ -63,6 +63,8 @@ try
     builder.Services.AddSingleton<DiscordRestClient>();
     builder.Services.AddHostedService<DiscordStartupService>();
 
+    builder.Services.AddHttpClient();
+    
     // Configure Authentication and Discord OAuth
     builder.Services.AddDiscordAuth(appConfig);
 

--- a/Blink3.Bot/Modules/MoveMessageModule.cs
+++ b/Blink3.Bot/Modules/MoveMessageModule.cs
@@ -31,7 +31,7 @@ public class MoveMessageModule(IHttpClientFactory httpClientFactory) : BlinkModu
     }
 
     [ComponentInteraction("blink-move-message_*_*")]
-    public async Task MoveMessageTo(string channelIdStr, string messageIdStr, IEnumerable<SocketChannel> channels)
+    public async Task MoveMessageTo(string channelIdStr, string messageIdStr, SocketChannel[] channels)
     {
         await DeferAsync(true);
 


### PR DESCRIPTION
Changed the MoveMessageTo method in the MoveMessageModule to take an array instead of an IEnumerable. Added HttpClient to the services in Program.cs to support HTTP communication within the application. These changes improve code clarity and expand the service capabilities.