### PR TITLE
Add 'discordsays' to user dictionary and allow CORS

### DIFF
--- a/Blink3.API/Program.cs
+++ b/Blink3.API/Program.cs
@@ -44,12 +44,15 @@ try
             ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
     });
 
+    List<string> origins = appConfig.ApiAllowedOrigins;
+    origins.Add("https://*.discordsays.com");
     // Configure Cors
     builder.Services.AddCors(options =>
     {
         options.AddPolicy("CorsPolicy",
             corsPolicyBuilder => corsPolicyBuilder
-                .WithOrigins(appConfig.ApiAllowedOrigins.ToArray())
+                .WithOrigins(origins.ToArray())
+                .SetIsOriginAllowedToAllowWildcardSubdomains()
                 .AllowAnyMethod()
                 .AllowAnyHeader()
                 .AllowCredentials());

--- a/Blink3.sln.DotSettings
+++ b/Blink3.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xml:space="preserve">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=discordsays/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=lavalink/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Wordle/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Wordles/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
Introduced 'discordsays' to the user dictionary in the .DotSettings file. Also configured Cross-Origin Resource Sharing (CORS) policy in the Program.cs file of the API to allow requests from 'discordsays' subdomains.