### PR TITLE
Update SelfContained property in Blink3.Bot.csproj

### DIFF
--- a/Blink3.Bot/Blink3.Bot.csproj
+++ b/Blink3.Bot/Blink3.Bot.csproj
@@ -9,7 +9,7 @@
         <UserSecretsId>14eff9f0-46d1-4c6d-a6f3-13b66b7fb75c</UserSecretsId>
         <InvariantGlobalization>false</InvariantGlobalization>
         <PublishTrimmed>true</PublishTrimmed>
-        <SelfContained>false</SelfContained>
+        <SelfContained>true</SelfContained>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Changed the SelfContained property from false to true in the Blink3.Bot.csproj file. This change is necessary to make the application fully self-contained, meaning it will include all necessary runtime files for deployment and operation.