### PR TITLE
Remove publishTrimmed and selfContained options

### DIFF
--- a/Blink3.Bot/Blink3.Bot.csproj
+++ b/Blink3.Bot/Blink3.Bot.csproj
@@ -8,8 +8,6 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <UserSecretsId>14eff9f0-46d1-4c6d-a6f3-13b66b7fb75c</UserSecretsId>
         <InvariantGlobalization>false</InvariantGlobalization>
-        <PublishTrimmed>true</PublishTrimmed>
-        <SelfContained>true</SelfContained>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
The commit removes the 'PublishTrimmed' and 'SelfContained' options from the Blink3.Bot.csproj file settings. These settings were not necessary for the project setup, helping to streamline project configuration.