### PR TITLE
Include all definitions in definition module

### DIFF
--- a/Blink3.Core/Extensions/StringExtensions.cs
+++ b/Blink3.Core/Extensions/StringExtensions.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace Blink3.Core.Extensions;
 
 public static class StringExtensions
@@ -13,5 +15,28 @@ public static class StringExtensions
         if (!ulong.TryParse(input, out ulong result)) throw new FormatException("Invalid format for ulong conversion");
 
         return result;
+    }
+
+    /// <summary>
+    ///     Converts a string to title case.
+    /// </summary>
+    /// <param name="str">The input string to convert.</param>
+    /// <returns>The converted string in title case.</returns>
+    public static string ToTitleCase(this string str)
+    {
+        if (string.IsNullOrWhiteSpace(str)) return str;
+        TextInfo textInfo = CultureInfo.CurrentCulture.TextInfo;
+        return textInfo.ToTitleCase(str);
+    }
+
+    /// <summary>
+    ///     Converts a string to sentence case.
+    /// </summary>
+    /// <param name="str">The input string to convert.</param>
+    /// <returns>The converted string in sentence case.</returns>
+    public static string ToSentenceCase(this string str)
+    {
+        if (string.IsNullOrWhiteSpace(str)) return str;
+        return char.ToUpper(str[0]) + str[1..].ToLower();
     }
 }


### PR DESCRIPTION
The Define() method in WordleModule now handles exceptions better. If the word definition fetch fails, it sends out an error response. The method now also uses EmbedFieldBuilder for presenting word definitions. Additionally, StringExtensions has been enhanced with ToTitleCase and ToSentenceCase methods for string conversion.