### PR TITLE
Add return in ServiceCollectionExtensions and update development dock…

### DIFF
--- a/.idea/.idea.Blink3/.idea/dataSources.xml
+++ b/.idea/.idea.Blink3/.idea/dataSources.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
+    <data-source source="LOCAL" name="Blink DB" uuid="2c0f0496-0d7a-4265-86e1-939756e9fa05">
+      <driver-ref>postgresql</driver-ref>
+      <synchronize>true</synchronize>
+      <configured-by-url>true</configured-by-url>
+      <jdbc-driver>org.postgresql.Driver</jdbc-driver>
+      <jdbc-url>jdbc:postgresql://localhost:5432/postgres</jdbc-url>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
+    <data-source source="LOCAL" name="Blink Cache" uuid="3382c99c-e84d-4dc2-be85-f0173a573c3e">
+      <driver-ref>redis</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>jdbc.RedisDriver</jdbc-driver>
+      <jdbc-url>jdbc:redis://localhost:6379/</jdbc-url>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
+  </component>
+</project>

--- a/Blink3.Core/Caching/Extensions/ServiceCollectionExtensions.cs
+++ b/Blink3.Core/Caching/Extensions/ServiceCollectionExtensions.cs
@@ -24,6 +24,7 @@ public static class ServiceCollectionExtensions
         {
             services.AddStackExchangeRedisCache(options => { options.Configuration = config.Redis.ConnectionString; });
             services.AddSingleton<ICachingService, RedisCachingService>();
+            return;
         }
 
         services.AddMemoryCache();

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -1,6 +1,14 @@
 version: '3.8'
 
 services:
+  blink3.db:
+    ports:
+      - "5432:5432"
+
+  blink3.cache:
+    ports:
+      - "6379:6379"
+
   blink3.bot:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development


### PR DESCRIPTION
…er-compose

Added an early return statement in ServiceCollectionExtensions for Redis services. Additionally, generated an idea configuration for Blink DB and Cache. Expanded docker-compose.development.yml to include port configuration for blink3.db and blink3.cache services.