### PR TITLE
Add feature to delete and log messages with attachments

### DIFF
--- a/Blink3.Bot/Modules/DeleteMessageModule.cs
+++ b/Blink3.Bot/Modules/DeleteMessageModule.cs
@@ -1,0 +1,93 @@
+using Blink3.Core.Entities;
+using Blink3.Core.Interfaces;
+using Blink3.Core.Repositories.Interfaces;
+using Discord;
+using Discord.Interactions;
+
+namespace Blink3.Bot.Modules;
+
+[RequireContext(ContextType.Guild)]
+[RequireUserPermission(GuildPermission.ManageMessages)]
+[CommandContextType(InteractionContextType.Guild)]
+[IntegrationType(ApplicationIntegrationType.GuildInstall)]
+public class DeleteMessageModule(IBlinkGuildRepository blinkGuildRepository,
+    IDiscordAttachmentService discordAttachmentService)
+    : BlinkModuleBase<IInteractionContext>(blinkGuildRepository)
+{
+    private readonly IBlinkGuildRepository _blinkGuildRepository = blinkGuildRepository;
+    
+    [MessageCommand("Delete & log")]
+    public async Task DeleteAndLogMessage(IMessage message)
+    {
+        BlinkGuild guildConfig = await FetchConfig();
+        IMessage fullMessage = await Context.Channel.GetMessageAsync(message.Id);
+        
+        IMessageChannel? logChannel = await GetValidatedLogChannel(guildConfig, fullMessage);
+        if (logChannel is null) return;
+        
+        EmbedBuilder embed = BuildEmbed(fullMessage);
+        
+        if (fullMessage.Attachments.Count > 0)
+        {
+            await DeferAsync(true);
+            using IDisposableCollection<FileAttachment> attachments =
+                await discordAttachmentService.DownloadAsync(message, true);
+            await logChannel.SendFilesAsync(attachments: attachments, text: "", embed: embed.Build());
+        }
+        else
+        {
+            await logChannel.SendMessageAsync(embed: embed.Build());
+        }
+        
+        await message.DeleteAsync();
+        await RespondSuccessAsync("Message Deleted", "The message has been deleted and logged.");
+    }
+    
+    private EmbedBuilder BuildEmbed(IMessage fullMessage)
+    {
+        return new EmbedBuilder()
+            .WithAuthor(fullMessage.Author)
+            .WithDescription(fullMessage.Content)
+            .WithTimestamp(fullMessage.Timestamp)
+            .WithFields(new EmbedFieldBuilder[] {
+                new EmbedFieldBuilder().WithName("Deleted by").WithValue($"{Context.User.Mention}"),
+                new EmbedFieldBuilder().WithName("Channel").WithValue($"<#{Context.Channel.Id}>")
+            })
+            .WithFooter($"User ID: {fullMessage.Author.Id}");
+    }
+    
+    private async Task<IMessageChannel?> GetValidatedLogChannel(BlinkGuild guildConfig, IMessage fullMessage)
+    {
+        if (guildConfig.LoggingChannelId is null)
+        {
+            await RespondErrorAsync("No logging channel set",
+                "You must set a logging channel before you can delete and log messages.");
+            return null;
+        }
+
+        IMessageChannel logChannel = await Context.Guild.GetTextChannelAsync(guildConfig.LoggingChannelId.Value);
+        if (logChannel is null)
+        {
+            await RespondErrorAsync("Logging channel not found",
+                "The logging channel could not be found. Please set a valid logging channel.");
+            return null;
+        }
+        
+        if (logChannel.Id == Context.Channel.Id)
+        {
+            await RespondErrorAsync("Cannot log to the same channel",
+                "You cannot log messages to the same channel you are deleting them from.");
+            return null;
+        }
+        
+        // ReSharper disable once InvertIf
+        if (fullMessage.Author.IsBot || fullMessage.Author.IsWebhook) 
+        {
+            await RespondErrorAsync("Cannot delete bot messages",
+                "You cannot delete messages from bots or webhooks.");
+            return null;
+        }
+
+        return logChannel;
+    }
+}

--- a/Blink3.Bot/Modules/MoveMessageModule.cs
+++ b/Blink3.Bot/Modules/MoveMessageModule.cs
@@ -116,7 +116,7 @@ public class MoveMessageModule(IDiscordAttachmentService discordAttachmentServic
         if (message.Attachments.Count is not 0)
         {
             using IDisposableCollection<FileAttachment> attachments =
-                await discordAttachmentService.DownloadAttachmentsFromMessageAsync(message);
+                await discordAttachmentService.DownloadAsync(message);
             await SendMessageWithAttachments(client, message, attachments);
         }
         else

--- a/Blink3.Bot/Modules/WordleModule.cs
+++ b/Blink3.Bot/Modules/WordleModule.cs
@@ -32,7 +32,7 @@ public class WordleModule(
             return;
         }
 
-        _ = await wordleGameService.StartNewGameAsync(Context.Channel.Id, "en", 5);
+        wordleGameService.StartNewGameAsync(Context.Channel.Id, "en", 5).Forget();
 
         await RespondSuccessAsync("Wordle started", "A new wordle has started.  Type `/guess` guess it.", false);
     }

--- a/Blink3.Bot/Services/DiscordAttachmentService.cs
+++ b/Blink3.Bot/Services/DiscordAttachmentService.cs
@@ -7,10 +7,10 @@ namespace Blink3.Bot.Services;
 /// <inheritdoc />
 public class DiscordAttachmentService(HttpClient httpClient) : IDiscordAttachmentService
 {
-    public async Task<IDisposableCollection<FileAttachment>> DownloadAttachmentsFromMessageAsync(IMessage message)
+    public async Task<IDisposableCollection<FileAttachment>> DownloadAsync(IMessage message, bool? spoiler = null)
     {
         IEnumerable<Task<FileAttachment>> downloadTasks = message.Attachments.Select(
-            async attachment => await CreateFileAttachmentFromUrlAsync(attachment));
+            async attachment => await CreateFileAttachmentFromUrlAsync(attachment, spoiler));
         FileAttachment[] attachments = await Task.WhenAll(downloadTasks);
         return new DisposableCollection<FileAttachment>(attachments);
     }
@@ -21,7 +21,8 @@ public class DiscordAttachmentService(HttpClient httpClient) : IDiscordAttachmen
     /// <param name="attachment">The attachment from which to retrieve the file.</param>
     /// <returns>The FileAttachment object representing the retrieved file attachment.</returns>
     private async Task<FileAttachment> CreateFileAttachmentFromUrlAsync(
-        IAttachment attachment)
+        IAttachment attachment,
+        bool? spoiler)
     {
         using HttpResponseMessage response = await httpClient.GetAsync(attachment.Url);
         response.EnsureSuccessStatusCode();
@@ -36,6 +37,6 @@ public class DiscordAttachmentService(HttpClient httpClient) : IDiscordAttachmen
             ms,
             attachment.Filename,
             attachment.Description,
-            attachment.IsSpoiler());
+            spoiler ?? attachment.IsSpoiler());
     }
 }

--- a/Blink3.Core/Entities/BlinkGuild.cs
+++ b/Blink3.Core/Entities/BlinkGuild.cs
@@ -54,6 +54,8 @@ public class BlinkGuild : ICacheKeyIdentifiable
         get => _incorrectTileColour ?? WordleImageConstants.IncorrectTileColour;
         set => _incorrectTileColour = value;
     }
+    
+    public ulong? LoggingChannelId { get; set; }
 
     public string GetCacheKey()
     {

--- a/Blink3.Core/Interfaces/IDiscordAttachmentService.cs
+++ b/Blink3.Core/Interfaces/IDiscordAttachmentService.cs
@@ -11,6 +11,7 @@ public interface IDiscordAttachmentService
     ///     Downloads the attachments from a message.
     /// </summary>
     /// <param name="message">The Discord message containing the attachments.</param>
+    /// <param name="spoiler">Set the spoiler property of all retrieved attachments. Defaults to unmodified.</param>
     /// <returns>A list of downloaded file attachments.</returns>
-    Task<IDisposableCollection<FileAttachment>> DownloadAttachmentsFromMessageAsync(IMessage message);
+    Task<IDisposableCollection<FileAttachment>> DownloadAsync(IMessage message, bool? spoiler = null);
 }

--- a/Blink3.DataAccess/Migrations/20240412202347_AddLoggingChannel.Designer.cs
+++ b/Blink3.DataAccess/Migrations/20240412202347_AddLoggingChannel.Designer.cs
@@ -2,6 +2,7 @@
 using Blink3.DataAccess;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -10,9 +11,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Blink3.DataAccess.Migrations
 {
     [DbContext(typeof(BlinkDbContext))]
-    partial class BlinkDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240412202347_AddLoggingChannel")]
+    partial class AddLoggingChannel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Blink3.DataAccess/Migrations/20240412202347_AddLoggingChannel.cs
+++ b/Blink3.DataAccess/Migrations/20240412202347_AddLoggingChannel.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Blink3.DataAccess.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLoggingChannel : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "LoggingChannelId",
+                table: "BlinkGuilds",
+                type: "numeric(20,0)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LoggingChannelId",
+                table: "BlinkGuilds");
+        }
+    }
+}


### PR DESCRIPTION
Implemented a feature to delete and log Discord messages, including those with attachments. Also, added the ability to set a logging channel for each server and made changes to the migrations to accommodate this new feature. Updated method arguments in IDiscordAttachmentService for better functionality.