### PR TITLE
Integrate Wordle game statistics tracking

### DIFF
--- a/.idea/.idea.Blink3/Docker/docker-compose.generated.override.yml
+++ b/.idea/.idea.Blink3/Docker/docker-compose.generated.override.yml
@@ -5,55 +5,105 @@ services:
       context: "/Users/joshua/RiderProjects/Blink3"
       dockerfile: "Blink3.API/Dockerfile"
       target: "base"
+      args:
+        BUILD_CONFIGURATION: "Debug"
     command: []
     entrypoint:
-    - "dotnet"
-    - "/app/bin/Debug/net9.0/Blink3.API.dll"
+    - "/opt/JetBrains/RiderDebuggerTools/linux-arm64/JetBrains.Debugger.Worker"
+    - "--runtimeconfig"
+    - "/opt/JetBrains/RiderDebuggerTools/JetBrains.Debugger.Worker.runtimeconfig.json"
+    - "--mode=server"
+    - "--frontend-port=57000"
+    - "--backend-port=57200"
+    - "--roslyn-worker-port=57439"
+    - "--timeout=60"
     environment:
       DOTNET_USE_POLLING_FILE_WATCHER: "true"
+      RIDER_DEBUGGER_LOG_DIR: "/var/opt/JetBrains/RiderDebuggerTools"
+      RESHARPER_LOG_CONF: "/etc/opt/JetBrains/RiderDebuggerTools/backend-log.xml"
     image: "ghcr.io/epicofficer/blink3.api:dev"
-    ports: []
+    ports:
+    - "127.0.0.1:57039:57000"
+    - "127.0.0.1:57239:57200"
+    - "127.0.0.1:57439:57439"
     volumes:
     - "/Users/joshua/RiderProjects/Blink3/Blink3.API:/app:rw"
     - "/Users/joshua/RiderProjects/Blink3:/src:rw"
     - "/Users/joshua/.microsoft/usersecrets:/home/app/.microsoft/usersecrets"
     - "/Users/joshua/.nuget/packages:/home/app/.nuget/packages"
+    - "/Users/joshua/.local/share/JetBrains/RiderRemoteDebugger/2025.1.2/LinuxArm64:/opt/JetBrains/RiderDebuggerTools"
+    - "/Applications/Rider.app/Contents/bin/backend-log.xml:/etc/opt/JetBrains/RiderDebuggerTools/backend-log.xml"
+    - "/Users/joshua/Library/Logs/JetBrains/Rider2025.1/DebuggerWorker/JetBrains.Debugger.Worker.2025_6_07_15_33_40:/var/opt/JetBrains/RiderDebuggerTools:rw"
     working_dir: "/app"
   bot:
     build:
       context: "/Users/joshua/RiderProjects/Blink3"
       dockerfile: "Blink3.Bot/Dockerfile"
       target: "base"
+      args:
+        BUILD_CONFIGURATION: "Debug"
     command: []
     entrypoint:
-    - "dotnet"
-    - "/app/bin/Debug/net9.0/Blink3.Bot.dll"
+    - "/opt/JetBrains/RiderDebuggerTools/linux-arm64/JetBrains.Debugger.Worker"
+    - "--runtimeconfig"
+    - "/opt/JetBrains/RiderDebuggerTools/JetBrains.Debugger.Worker.runtimeconfig.json"
+    - "--mode=server"
+    - "--frontend-port=57000"
+    - "--backend-port=57200"
+    - "--roslyn-worker-port=57440"
+    - "--timeout=60"
     environment:
       DOTNET_USE_POLLING_FILE_WATCHER: "true"
+      RIDER_DEBUGGER_LOG_DIR: "/var/opt/JetBrains/RiderDebuggerTools"
+      RESHARPER_LOG_CONF: "/etc/opt/JetBrains/RiderDebuggerTools/backend-log.xml"
     image: "ghcr.io/epicofficer/blink3.bot:dev"
-    ports: []
+    ports:
+    - "127.0.0.1:57040:57000"
+    - "127.0.0.1:57240:57200"
+    - "127.0.0.1:57440:57440"
     volumes:
     - "/Users/joshua/RiderProjects/Blink3/Blink3.Bot:/app:rw"
     - "/Users/joshua/RiderProjects/Blink3:/src:rw"
     - "/Users/joshua/.microsoft/usersecrets:/home/app/.microsoft/usersecrets"
     - "/Users/joshua/.nuget/packages:/home/app/.nuget/packages"
+    - "/Users/joshua/.local/share/JetBrains/RiderRemoteDebugger/2025.1.2/LinuxArm64:/opt/JetBrains/RiderDebuggerTools"
+    - "/Applications/Rider.app/Contents/bin/backend-log.xml:/etc/opt/JetBrains/RiderDebuggerTools/backend-log.xml"
+    - "/Users/joshua/Library/Logs/JetBrains/Rider2025.1/DebuggerWorker/JetBrains.Debugger.Worker.2025_6_07_15_33_40:/var/opt/JetBrains/RiderDebuggerTools:rw"
     working_dir: "/app"
   web:
     build:
       context: "/Users/joshua/RiderProjects/Blink3"
       dockerfile: "Blink3.Web/Dockerfile"
       target: "base"
+      args:
+        BUILD_CONFIGURATION: "Debug"
     command: []
     entrypoint:
-    - "dotnet"
-    - "/app/../../../.nuget/packages/microsoft.aspnetcore.components.webassembly.devserver/9.0.5/tools/blazor-devserver.dll"
+    - "/opt/JetBrains/RiderDebuggerTools/linux-musl-arm64/dotnet/dotnet"
+    - "exec"
+    - "--runtimeconfig"
+    - "/opt/JetBrains/RiderDebuggerTools/JetBrains.Debugger.Worker.runtimeconfig.json"
+    - "/opt/JetBrains/RiderDebuggerTools/JetBrains.Debugger.Worker.exe"
+    - "--mode=server"
+    - "--frontend-port=57000"
+    - "--backend-port=57200"
+    - "--roslyn-worker-port=57441"
+    - "--timeout=60"
     environment:
       ASPNETCORE_ENVIRONMENT: "Development"
       DOTNET_USE_POLLING_FILE_WATCHER: "true"
+      RIDER_DEBUGGER_LOG_DIR: "/var/opt/JetBrains/RiderDebuggerTools"
+      RESHARPER_LOG_CONF: "/etc/opt/JetBrains/RiderDebuggerTools/backend-log.xml"
     image: "ghcr.io/epicofficer/blink3.web:dev"
-    ports: []
+    ports:
+    - "127.0.0.1:57041:57000"
+    - "127.0.0.1:57241:57200"
+    - "127.0.0.1:57441:57441"
     volumes:
     - "/Users/joshua/RiderProjects/Blink3/Blink3.Web:/app:rw"
     - "/Users/joshua/RiderProjects/Blink3:/src:rw"
     - "/Users/joshua/.nuget/packages:/root/.nuget/packages"
+    - "/Users/joshua/.local/share/JetBrains/RiderRemoteDebugger/2025.1.2/LinuxMuslArm64:/opt/JetBrains/RiderDebuggerTools"
+    - "/Applications/Rider.app/Contents/bin/backend-log.xml:/etc/opt/JetBrains/RiderDebuggerTools/backend-log.xml"
+    - "/Users/joshua/Library/Logs/JetBrains/Rider2025.1/DebuggerWorker/JetBrains.Debugger.Worker.2025_6_07_15_33_40:/var/opt/JetBrains/RiderDebuggerTools:rw"
     working_dir: "/app"

--- a/Blink3.Bot/Modules/WordleModule.cs
+++ b/Blink3.Bot/Modules/WordleModule.cs
@@ -1,6 +1,7 @@
 using Blink3.Bot.Enums;
 using Blink3.Bot.Extensions;
 using Blink3.Core.Entities;
+using Blink3.Core.Enums;
 using Blink3.Core.Extensions;
 using Blink3.Core.Interfaces;
 using Blink3.Core.Models;
@@ -18,10 +19,31 @@ public class WordleModule(
     IWordsClientService wordsClientService,
     IBlinkGuildRepository blinkGuildRepository,
     IBlinkUserRepository blinkUserRepository,
+    IGameStatisticsRepository gameStatisticsRepository,
     IWordRepository wordRepository) : BlinkModuleBase<IInteractionContext>(blinkGuildRepository)
 {
     private ulong GameId => Context.Interaction.ChannelId ?? Context.User.Id;
 
+    private static GameStatistics UpdateStreak(GameStatistics stats)
+    {
+        DateTime time = DateTime.UtcNow;
+        if (time - stats.LastActivity < TimeSpan.FromDays(1))
+        {
+            return stats;
+        }
+
+        if (time - stats.LastActivity < TimeSpan.FromDays(2))
+        {
+            stats.CurrentStreak++;
+            stats.MaxStreak = Math.Max(stats.MaxStreak, stats.CurrentStreak);
+            return stats;
+        }
+        
+        stats.CurrentStreak = 0;
+        stats.MaxStreak = Math.Max(stats.MaxStreak, stats.CurrentStreak);
+        return stats;
+    }
+    
     [SlashCommand("wordle", "Start a new game of wordle")]
     public async Task Start(WordleLanguageEnum language = WordleLanguageEnum.English)
     {
@@ -47,7 +69,11 @@ public class WordleModule(
         };
 
         wordleGameService.StartNewGameAsync(GameId, lang, 5).Forget();
-
+        GameStatistics stats = await gameStatisticsRepository.GetOrCreateGameStatistics(Context.User.Id, GameType.Wordle);
+        stats.LastActivity = DateTime.UtcNow;
+        stats = UpdateStreak(stats);
+        await gameStatisticsRepository.UpdateAsync(stats);
+        
         List<EmbedFieldBuilder> fields =
         [
             new()
@@ -88,10 +114,21 @@ public class WordleModule(
             return;
         }
 
+        GameStatistics stats = await gameStatisticsRepository.GetOrCreateGameStatistics(Context.User.Id, GameType.Wordle);
+        stats.LastActivity = DateTime.UtcNow;
+        stats = UpdateStreak(stats);
+
+        if (wordle.Players.Contains(Context.User.Id) is false)
+        {
+            wordle.Players.Add(Context.User.Id);
+        }
+        
         WordleGuess guess = guessResult.SafeValue();
         string text = string.Empty;
         if (guess.IsCorrect)
         {
+            stats.GamesWon++;
+            stats.GamesPlayed++;
             text = $"**Correct!** You got it in {wordle.TotalAttempts} tries.  ";
             int pointsToAdd = 11 - wordle.TotalAttempts;
             if (pointsToAdd > 0)
@@ -101,9 +138,18 @@ public class WordleModule(
                 await blinkUserRepository.UpdateAsync(user);
                 text += $"You have been awarded {pointsToAdd} points";
             }
+            
+            foreach (ulong player in wordle.Players.ToHashSet().Where(u => u != Context.User.Id))
+            {
+                GameStatistics playerStats = await gameStatisticsRepository.GetOrCreateGameStatistics(player, GameType.Wordle);
+                playerStats.GamesPlayed++;
+                await gameStatisticsRepository.UpdateAsync(playerStats);
+            }
 
             await wordleRepository.DeleteAsync(wordle);
         }
+        
+        await gameStatisticsRepository.UpdateAsync(stats);
 
         using MemoryStream image = new();
         await wordleGameService.GenerateImageAsync(guess, image, await FetchConfig());
@@ -163,6 +209,56 @@ public class WordleModule(
         await RespondPlainAsync($"You currently have {points} point{(points != 1 ? "s" : null)}.", ephemeral: false);
     }
 
+    [SlashCommand("statistics", "View your Wordle game statistics")]
+    public async Task Statistics()
+    {
+        await DeferAsync();
+
+        // Retrieve the user's game statistics
+        GameStatistics stats = await gameStatisticsRepository.GetOrCreateGameStatistics(Context.User.Id, GameType.Wordle);
+
+        // Calculate the win percentage
+        double winPercentage = stats.GamesPlayed > 0
+            ? Math.Round((double)stats.GamesWon / stats.GamesPlayed * 100, 2)
+            : 0;
+
+        // Build an embed response
+        EmbedFieldBuilder[] fields =
+        [
+            new()
+            {
+                Name = "Games Played",
+                Value = $"{stats.GamesPlayed}"
+            },
+            new()
+            {
+                Name = "Games Won",
+                Value = $"{stats.GamesWon}"
+            },
+            new()
+            {
+                Name = "Win Percentage",
+                Value = $"{winPercentage}%"
+            },
+            new()
+            {
+                Name = "Current Streak",
+                Value = $"{stats.CurrentStreak}"
+            },
+            new()
+            {
+                Name = "Max Streak",
+                Value = $"{stats.MaxStreak}"
+            }
+        ];
+
+        await RespondPlainAsync(
+            "Your Wordle Statistics",
+            embedFields: fields,
+            ephemeral: false
+        );
+    }
+    
     [SlashCommand("leaderboard", "Display points leaderboard")]
     public async Task Leaderboard()
     {

--- a/Blink3.Core/Entities/BlinkUser.cs
+++ b/Blink3.Core/Entities/BlinkUser.cs
@@ -18,4 +18,6 @@ public class BlinkUser
     ///     Represents the number of points for a BlinkUser.
     /// </summary>
     public int Points { get; set; }
+    
+    public ICollection<GameStatistics> GameStatistics { get; set; } = [];
 }

--- a/Blink3.Core/Entities/GameStatistics.cs
+++ b/Blink3.Core/Entities/GameStatistics.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+using Blink3.Core.Enums;
+
+namespace Blink3.Core.Entities;
+
+public class GameStatistics
+{
+    [Required]
+    [Key]
+    public int Id { get; set; }
+    
+    public ulong BlinkUserId { get; set; } // FK to BlinkUser
+    public BlinkUser BlinkUser { get; set; } = null!;
+    
+    public GameType Type { get; set; }
+    
+    public int GamesPlayed { get; set; }
+    public int GamesWon { get; set; }
+    public int CurrentStreak { get; set; }
+    public int MaxStreak { get; set; }
+    public DateTime? LastActivity { get; set; }
+}

--- a/Blink3.Core/Entities/Wordle.cs
+++ b/Blink3.Core/Entities/Wordle.cs
@@ -40,6 +40,11 @@ public class Wordle
     public string WordToGuess { get; set; } = string.Empty;
 
     /// <summary>
+    ///     Represents the players in the Wordle game.
+    /// </summary>
+    public ICollection<ulong> Players { get; set; } = [];
+    
+    /// <summary>
     ///     The total number of guesses in this wordle game.
     /// </summary>
     public int TotalAttempts => Guesses.Count;

--- a/Blink3.Core/Enums/GameType.cs
+++ b/Blink3.Core/Enums/GameType.cs
@@ -1,0 +1,6 @@
+namespace Blink3.Core.Enums;
+
+public enum GameType
+{
+    Wordle,
+}

--- a/Blink3.Core/Repositories/Interfaces/IBlinkUserRepository.cs
+++ b/Blink3.Core/Repositories/Interfaces/IBlinkUserRepository.cs
@@ -1,4 +1,5 @@
 using Blink3.Core.Entities;
+using Blink3.Core.Enums;
 
 namespace Blink3.Core.Repositories.Interfaces;
 

--- a/Blink3.Core/Repositories/Interfaces/IGameStatisticsRepository.cs
+++ b/Blink3.Core/Repositories/Interfaces/IGameStatisticsRepository.cs
@@ -1,0 +1,12 @@
+using Blink3.Core.Entities;
+using Blink3.Core.Enums;
+
+namespace Blink3.Core.Repositories.Interfaces;
+
+/// <summary>
+///     Represents a repository for accessing and manipulating GameStatistics entities.
+/// </summary>
+public interface IGameStatisticsRepository : IGenericRepository<GameStatistics>
+{
+    public Task<GameStatistics> GetOrCreateGameStatistics(ulong userId, GameType gameType);
+}

--- a/Blink3.DataAccess/Blink3.DataAccess.csproj
+++ b/Blink3.DataAccess/Blink3.DataAccess.csproj
@@ -12,6 +12,10 @@
 
     <ItemGroup>
         <PackageReference Include="EFCore.BulkExtensions.PostgreSql" Version="9.0.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.5">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.5" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.Design" Version="1.1.0"/>

--- a/Blink3.DataAccess/BlinkDBContext.cs
+++ b/Blink3.DataAccess/BlinkDBContext.cs
@@ -30,6 +30,11 @@ public class BlinkDbContext : DbContext
     public DbSet<BlinkUser> BlinkUsers => Set<BlinkUser>();
 
     /// <summary>
+    ///     Represents a collection of game statistics entities in the BlinkDbContext.
+    /// </summary>
+    public DbSet<GameStatistics> GameStatistics => Set<GameStatistics>();
+
+    /// <summary>
     ///     Represents a user's "to do" items.
     /// </summary>
     public DbSet<UserTodo> UserTodos => Set<UserTodo>();
@@ -79,6 +84,14 @@ public class BlinkDbContext : DbContext
             entity.Property(p => p.CorrectTileColour).IsRequired(false);
             entity.Property(p => p.MisplacedTileColour).IsRequired(false);
             entity.Property(p => p.IncorrectTileColour).IsRequired(false);
+        });
+
+        modelBuilder.Entity<BlinkUser>(entity =>
+        {
+            entity.HasMany(b => b.GameStatistics)
+                .WithOne(g => g.BlinkUser)
+                .HasForeignKey(g => g.BlinkUserId)
+                .OnDelete(DeleteBehavior.Cascade);
         });
 
         modelBuilder.Entity<TempVc>(p => p.HasKey(t => new { t.GuildId, t.ChannelId }));

--- a/Blink3.DataAccess/Extensions/ServiceCollectionExtensions.cs
+++ b/Blink3.DataAccess/Extensions/ServiceCollectionExtensions.cs
@@ -20,11 +20,13 @@ public static class ServiceCollectionExtensions
     {
         if (!string.IsNullOrWhiteSpace(configuration.ConnectionStrings.DefaultConnection))
             services.AddDbContext<BlinkDbContext>(options =>
-                options.UseNpgsql(configuration.ConnectionStrings.DefaultConnection));
+                options.UseNpgsql(configuration.ConnectionStrings.DefaultConnection,
+                    b => b.MigrationsAssembly("Blink3.DataAccess")));
 
         services.AddScoped(typeof(IGenericRepository<>), typeof(GenericRepository<>));
         services.AddScoped<IBlinkGuildRepository, BlinkGuildRepository>();
         services.AddScoped<IBlinkUserRepository, BlinkUserRepository>();
+        services.AddScoped<IGameStatisticsRepository, GameStatisticsRepository>();
         services.AddScoped<IUserTodoRepository, UserTodoRepository>();
         services.AddScoped<IWordRepository, WordRepository>();
         services.AddScoped<IWordleRepository, WordleRepository>();

--- a/Blink3.DataAccess/Migrations/20250607094257_GameStats.Designer.cs
+++ b/Blink3.DataAccess/Migrations/20250607094257_GameStats.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Blink3.DataAccess;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Blink3.DataAccess.Migrations
 {
     [DbContext(typeof(BlinkDbContext))]
-    partial class BlinkDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250607094257_GameStats")]
+    partial class GameStats
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -201,10 +204,6 @@ namespace Blink3.DataAccess.Migrations
                     b.Property<string>("Language")
                         .IsRequired()
                         .HasColumnType("text");
-
-                    b.PrimitiveCollection<decimal[]>("Players")
-                        .IsRequired()
-                        .HasColumnType("numeric(20,0)[]");
 
                     b.Property<string>("WordToGuess")
                         .IsRequired()

--- a/Blink3.DataAccess/Migrations/20250607094257_GameStats.cs
+++ b/Blink3.DataAccess/Migrations/20250607094257_GameStats.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Blink3.DataAccess.Migrations
+{
+    /// <inheritdoc />
+    public partial class GameStats : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "GameStatistics",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    BlinkUserId = table.Column<decimal>(type: "numeric(20,0)", nullable: false),
+                    Type = table.Column<int>(type: "integer", nullable: false),
+                    GamesPlayed = table.Column<int>(type: "integer", nullable: false),
+                    GamesWon = table.Column<int>(type: "integer", nullable: false),
+                    CurrentStreak = table.Column<int>(type: "integer", nullable: false),
+                    MaxStreak = table.Column<int>(type: "integer", nullable: false),
+                    LastActivity = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_GameStatistics", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_GameStatistics_BlinkUsers_BlinkUserId",
+                        column: x => x.BlinkUserId,
+                        principalTable: "BlinkUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GameStatistics_BlinkUserId",
+                table: "GameStatistics",
+                column: "BlinkUserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "GameStatistics");
+        }
+    }
+}

--- a/Blink3.DataAccess/Migrations/20250607121557_WordleParticipants.Designer.cs
+++ b/Blink3.DataAccess/Migrations/20250607121557_WordleParticipants.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Blink3.DataAccess;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Blink3.DataAccess.Migrations
 {
     [DbContext(typeof(BlinkDbContext))]
-    partial class BlinkDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250607121557_WordleParticipants")]
+    partial class WordleParticipants
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Blink3.DataAccess/Migrations/20250607121557_WordleParticipants.cs
+++ b/Blink3.DataAccess/Migrations/20250607121557_WordleParticipants.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Blink3.DataAccess.Migrations
+{
+    /// <inheritdoc />
+    public partial class WordleParticipants : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal[]>(
+                name: "Players",
+                table: "Wordles",
+                type: "numeric(20,0)[]",
+                nullable: false,
+                defaultValue: new decimal[0]);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Players",
+                table: "Wordles");
+        }
+    }
+}

--- a/Blink3.DataAccess/Migrations/20250607123946_WordleParticipants2.Designer.cs
+++ b/Blink3.DataAccess/Migrations/20250607123946_WordleParticipants2.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Blink3.DataAccess;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Blink3.DataAccess.Migrations
 {
     [DbContext(typeof(BlinkDbContext))]
-    partial class BlinkDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250607123946_WordleParticipants2")]
+    partial class WordleParticipants2
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Blink3.DataAccess/Migrations/20250607123946_WordleParticipants2.cs
+++ b/Blink3.DataAccess/Migrations/20250607123946_WordleParticipants2.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Blink3.DataAccess.Migrations
+{
+    /// <inheritdoc />
+    public partial class WordleParticipants2 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/Blink3.DataAccess/Repositories/BlinkUserRepository.cs
+++ b/Blink3.DataAccess/Repositories/BlinkUserRepository.cs
@@ -1,4 +1,5 @@
 using Blink3.Core.Entities;
+using Blink3.Core.Enums;
 using Blink3.Core.Repositories.Interfaces;
 using Microsoft.EntityFrameworkCore;
 

--- a/Blink3.DataAccess/Repositories/GameStatisticsRepository.cs
+++ b/Blink3.DataAccess/Repositories/GameStatisticsRepository.cs
@@ -1,0 +1,28 @@
+using Blink3.Core.Entities;
+using Blink3.Core.Enums;
+using Blink3.Core.Repositories.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Blink3.DataAccess.Repositories;
+
+/// <inheritdoc cref="IBlinkUserRepository" />
+public class GameStatisticsRepository(BlinkDbContext dbContext)
+    : GenericRepository<GameStatistics>(dbContext), IGameStatisticsRepository
+{
+    private readonly BlinkDbContext _dbContext = dbContext;
+    
+    public async Task<GameStatistics> GetOrCreateGameStatistics(ulong userId, GameType gameType)
+    {
+        GameStatistics? stats =
+            await _dbContext.GameStatistics.AsNoTracking()
+                .FirstOrDefaultAsync(s => s.BlinkUserId == userId && s.Type == gameType);
+        
+        if (stats is not null) return stats;
+        
+        return await AddAsync(new GameStatistics
+        {
+            BlinkUserId = userId,
+            Type = gameType
+        });
+    }
+}


### PR DESCRIPTION
Added `GameStatistics` entity and related database migrations to manage Wordle statistics like games played, games won, streaks, and activity. Updated `WordleModule` to include commands for viewing statistics and tracking game progress. Extended repositories and context for handling game statistics storage. Adjusted DI configuration for the new repository.